### PR TITLE
Update TranslatableListener on Laravel's locale.changed event

### DIFF
--- a/src/Translatable/TranslatableExtension.php
+++ b/src/Translatable/TranslatableExtension.php
@@ -7,6 +7,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Gedmo\Translatable\TranslatableListener;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use LaravelDoctrine\Extensions\GedmoExtension;
 
@@ -23,13 +24,20 @@ class TranslatableExtension extends GedmoExtension
     protected $repository;
 
     /**
-     * @param Application $application
-     * @param Repository  $repository
+     * @var Dispatcher
      */
-    public function __construct(Application $application, Repository $repository)
+    private $events;
+
+    /**
+     * @param Application $application
+     * @param Repository $repository
+     * @param Dispatcher $events
+     */
+    public function __construct(Application $application, Repository $repository, Dispatcher $events)
     {
         $this->application = $application;
         $this->repository  = $repository;
+        $this->events      = $events;
     }
 
     /**
@@ -44,6 +52,10 @@ class TranslatableExtension extends GedmoExtension
         $subscriber->setDefaultLocale($this->repository->get('app.locale'));
 
         $this->addSubscriber($subscriber, $manager, $reader);
+
+        $this->events->listen('locale.changed', function($locale) use ($subscriber) {
+            $subscriber->setTranslatableLocale($locale);
+        });
     }
 
     /**

--- a/tests/Translatable/TranslatableExtensionTest.php
+++ b/tests/Translatable/TranslatableExtensionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use LaravelDoctrine\Extensions\Translatable\TranslatableExtension;
 use Mockery as m;
@@ -17,10 +18,12 @@ class TranslatableExtensionTest extends ExtensionTestCase
                ->with('app.locale')->once()
                ->andReturn('en');
 
-        $extension = new TranslatableExtension(
-            $app,
-            $config
-        );
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('listen')
+            ->with('locale.changed', m::type('callable'))
+            ->once();
+
+        $extension = new TranslatableExtension($app, $config, $events);
 
         $extension->addSubscribers(
             $this->evm,


### PR DESCRIPTION
The TranslatableListener is storing the current locale when the extension is subscribed, and that's usually on ServiceProvider::register or boot. If the application changes its locale somewhere along the road (maybe middleware, or even in a late SP), the extension won't detect that change.

This PR hooks to Laravel's `"locale.changed"` event to update the listener with the new locale setting.
