### PR TITLE
Add method for identifying wrapped subscriber

### DIFF
--- a/src/ResolveUserDecorator.php
+++ b/src/ResolveUserDecorator.php
@@ -85,4 +85,15 @@ class ResolveUserDecorator implements EventSubscriber
     {
         return $this->wrapped->getNamespace();
     }
+
+    /**
+     * Get the class of extension event subscriber.
+     * Used to identify which event subscriber is wrapped by the resolver.
+     *
+     * @return string
+     */
+    public function getEventSubscriberClass()
+    {
+        return get_class($this->wrapped);
+    }
 }


### PR DESCRIPTION
Public method makes it possible to identify what event subscriber is wrapped in ResolveUserDecorator

Used to make the behavior for the default repository for  [Gedmo Loggable](https://github.com/Atlantic18/DoctrineExtensions/blob/v2.4.x/lib/Gedmo/Loggable/Entity/Repository/LogEntryRepository.php#L145) feasible. See [slack discussion](https://laraveldoctrine.slack.com/archives/C07HD2RS7/p1500561219663611).