### PR TITLE
 Don't try to resolve user if loading class metadata

### DIFF
--- a/src/ResolveUserDecorator.php
+++ b/src/ResolveUserDecorator.php
@@ -59,7 +59,7 @@ class ResolveUserDecorator implements EventSubscriber
      */
     public function __call($method, $params)
     {
-        if ($this->getGuard()->check()) {
+        if ($method !== 'loadClassMetadata' && $this->getGuard()->check()) {
             call_user_func([$this->wrapped, $this->userSetterMethod], $this->getGuard()->user());
         }
 


### PR DESCRIPTION
Fixes #38

This should be a non-breaking change since you should be covered by the other events that set the user `onFlush` and `prePersist`.