### PR TITLE
Fix issue related to usage of manual loading of annotations

### DIFF
--- a/src/GedmoExtensionsServiceProvider.php
+++ b/src/GedmoExtensionsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDoctrine\Extensions;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Gedmo\DoctrineExtensions;
@@ -80,6 +81,8 @@ class GedmoExtensionsServiceProvider extends ServiceProvider
                 $chain->getReader()
             );
         }
+
+        AnnotationRegistry::registerUniqueLoader('class_exists');
     }
 
     /**


### PR DESCRIPTION
Gedmo uses the AnnotationRegistry::registerFile which toggles the bool AnnotationRegistry$registerFileUsed. This causes AnnotationRegistry::loadAnnotationClass() to go into a mode where it expects all annotations to be loaded in a different manner, and not autoloaded. This behaviour from Gedmo was changed here doctrine-extensions/DoctrineExtensions#2558

Adding this custom loader makes the annotation registry "autoloadable".